### PR TITLE
Added support of help_heading attribute to clap attribute

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,16 +2,16 @@
 members = ["config-manager-proc", "examples"]
 
 [package]
-name = "config-manager"
+name = "tonysd-config-manager"
 version = "0.2.0"
 edition = "2021"
 authors = [
     "Mikhail Mikhailov <m.mikhailov@kryptonite.ru>",
-    "Nikolay Pakharev <n.pakharev@kryptonite.ru>",
+    "Nikolay Pakharev <n.pakharev@kryptonite.ru>"
 ]
 description = "Crate to build config from environment, command line and files"
 readme = "README.md"
-repository = "https://github.com/3xMike/config-manager"
+repository = "https://github.com/TonySD/config-manager"
 license = "MIT"
 keywords = ["macro", "configuration", "environment", "command-line", "config"]
 categories = ["config", "development-tools", "command-line-utilities"]
@@ -19,7 +19,7 @@ categories = ["config", "development-tools", "command-line-utilities"]
 [dependencies]
 clap = { version = "4.0.29", features = ["derive", "cargo"] }
 config = "0.13.0"
-config-manager-proc = { path = "./config-manager-proc", version = "0.2.0" }
+config-manager-proc = { path = "./config-manager-proc", version = "0.2.0", package = "tonysd-config-manager-proc" }
 ctor = "0.1.23"
 deser-hjson = "1.0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 > **Crate to build config from environment, command line and files**
+# Attention
+It's a fork of original [config-manager](https://github.com/3xMike/config-manager) crate, which is not updating anymore. I wanted to use some of new clap's features, so this repository exists.
+
 # Motivation
 Non-runtime data generally comes to a project from
 command line, environment and configuration files.\

--- a/config-manager-proc/Cargo.toml
+++ b/config-manager-proc/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "config-manager-proc"
+name = "tonysd-config-manager-proc"
 version = "0.2.0"
 edition = "2021"
 authors = [

--- a/config-manager-proc/src/utils/attributes.rs
+++ b/config-manager-proc/src/utils/attributes.rs
@@ -19,7 +19,7 @@ pub(crate) const SUBCOMMAND: &str = "subcommand";
 
 pub(super) const ALLOWED_CLAP_APP_ATTRS: &[&str] =
     &["name", "version", "author", "about", "long_about"];
-pub(super) const ALLOWED_CLAP_FIELD_ATTRS: &[&str] = &["help", "long_help", "short", "long"];
+pub(super) const ALLOWED_CLAP_FIELD_ATTRS: &[&str] = &["help", "long_help", "short", "long", "help_heading"];
 
 #[derive(EnumIter, strum_macros::Display)]
 pub(super) enum TopLevelAttr {

--- a/config-manager-proc/src/utils/field.rs
+++ b/config-manager-proc/src/utils/field.rs
@@ -23,6 +23,7 @@ pub(crate) struct NormalClapFieldInfo {
     pub(crate) short: Option<String>,
     pub(crate) help: Option<String>,
     pub(crate) long_help: Option<String>,
+    pub(crate) help_heading: Option<String>,
 }
 
 pub(crate) struct ProcessFieldResult {

--- a/config-manager-proc/src/utils/field/utils.rs
+++ b/config-manager-proc/src/utils/field/utils.rs
@@ -37,12 +37,17 @@ impl ToTokens for NormalClapFieldInfo {
                 None => TokenStream::new(),
                 Some(long_help) => format_to_tokens!(".long_help({long_help})"),
             };
+            let help_heading = match &self.help_heading {
+                None => TokenStream::new(),
+                Some(help_heading) => format_to_tokens!(".help_heading({help_heading})"),
+            };
             quote! {
                 clap::Arg::new(#name)
                 #long
                 #short
                 #help
                 #long_help
+                #help_heading
                 .num_args(1).required(false)
             }
         })

--- a/config-manager-proc/src/utils/parser/clap.rs
+++ b/config-manager-proc/src/utils/parser/clap.rs
@@ -20,6 +20,7 @@ pub(crate) struct ClapFieldParseResult {
     pub(crate) short: MaybeString,
     pub(crate) help: Option<String>,
     pub(crate) long_help: Option<String>,
+    pub(crate) help_heading: Option<String>,
 }
 
 impl ClapFieldParseResult {
@@ -50,6 +51,7 @@ impl ClapFieldParseResult {
             },
             help: self.help,
             long_help: self.long_help,
+            help_heading: self.help_heading,
         }
     }
 }
@@ -165,6 +167,12 @@ pub(crate) fn parse_clap_field_attribute(attributes: &MetaList) -> ClapFieldPars
             "long_help" => {
                 res.long_help = match atr {
                     Meta::Path(_) => panic!("long_help attribute can't be path"),
+                    other => meta_to_option(other),
+                }
+            }
+            "help_heading" => {
+                res.help_heading = match atr {
+                    Meta::Path(_) => panic!("help_heading attribute can't be path"),
                     other => meta_to_option(other),
                 }
             }

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -17,5 +17,5 @@ name = "json_syntax"
 path = "src/json_syntax.rs"
 
 [dependencies]
-config-manager = { path = ".." }
+config-manager = { path = "..", package = "tonysd-config-manager" }
 serde = { version = "1.0", features = ["derive"] }

--- a/examples/src/demo.rs
+++ b/examples/src/demo.rs
@@ -19,6 +19,7 @@ struct MethodConfig {
     #[source(clap(long, short, help_heading = "A heading"))]
     a: i32,
     #[source(
+        clap(long, short, help_heading = "A heading"),
         env(init_from = "&format!(\"b{}\", SUFFIX)"),
         default = "\"abc\".to_string()"
     )]

--- a/examples/src/demo.rs
+++ b/examples/src/demo.rs
@@ -16,7 +16,7 @@ const SUFFIX: &str = "_env";
     )
 )]
 struct MethodConfig {
-    #[source(clap(long, short))]
+    #[source(clap(long, short, help_heading = "A heading"))]
     a: i32,
     #[source(
         env(init_from = "&format!(\"b{}\", SUFFIX)"),


### PR DESCRIPTION
Hey!
I really love this crate, but it didn't have support of new clap feature - help_heading, that can help to organize clap help page output by sections of flags. So I added support for it!