### PR TITLE
NI: fix bugs and warnigns & use struct/field docs for CLI help

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,0 @@
-format_strings = true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,9 +5,13 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased] - ReleaseDate
+## [0.3.1](https://github.com/3xMike/config-manager/releases/tag/0.3.1) - 2025-03-12
+### Fixed
+- Bug "Can't deserialize ... EoF" on setting empty string via env/cli/config.
+
 ## [0.3.0](https://github.com/3xMike/config-manager/releases/tag/0.3.0) - 2025-03-12
 ### Changed
-- default and init_from now takes code without quotation marks. I.e. following old code is invalid:
+- `default` and `init_from` now takes code without quotation marks. I.e. following old code is invalid:
 ```rust
 #[config]
 struct Config {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.3.1](https://github.com/3xMike/config-manager/releases/tag/0.3.1) - 2025-03-12
 ### Fixed
 - Bug "Can't deserialize ... EoF" on setting empty string via env/cli/config.
+### Updated:
+- `deserialize_with` documentation.
 
 ## [0.3.0](https://github.com/3xMike/config-manager/releases/tag/0.3.0) - 2025-03-12
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - ReleaseDate
 ## [0.3.1](https://github.com/3xMike/config-manager/releases/tag/0.3.1) - 2025-03-12
+### Added
+- Allow to use clap(help), clap(long_help) and clap(long_about) without value.
+Doc comments will be used instead.
 ### Fixed
 - Bug "Can't deserialize ... EoF" on setting empty string via env/cli/config.
 ### Updated:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ members = ["config-manager-proc", "examples"]
 
 [package]
 name = "config-manager"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Mikhail Mikhailov <m.mikhailov@kryptonite.ru>",
@@ -19,7 +19,7 @@ categories = ["config", "development-tools", "command-line-utilities"]
 [dependencies]
 clap = { version = "4.0.29", features = ["derive", "cargo"] }
 config = "0.13.0"
-config-manager-proc = { path = "./config-manager-proc", version = "0.3.0" }
+config-manager-proc = { path = "./config-manager-proc", version = "0.3.1" }
 ctor = "0.1.23"
 deser-hjson = "1.0.2"
 serde = { version = "1.0", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -50,9 +50,10 @@ use config_manager::{config, ConfigInit};
 
 const SUFFIX: &str = "_env";
 
+/// This doc will be included to CLI long_about.
 #[derive(Debug)]
 #[config(
-    clap(version, author),
+    clap(version, author, long_about),
     env_prefix = "demo",
     file(
         format = "toml",
@@ -62,7 +63,8 @@ const SUFFIX: &str = "_env";
     )
 )]
 struct MethodConfig {
-    #[source(clap(long, short))]
+    /// This doc will be included to CLI help.
+    #[source(clap(long, short, help))]
     a: i32,
     #[source(
         env(init_from = &format!("b{}", SUFFIX)),

--- a/README.md
+++ b/README.md
@@ -65,13 +65,13 @@ struct MethodConfig {
     #[source(clap(long, short))]
     a: i32,
     #[source(
-        env(init_from = "&format!(\"b{}\", SUFFIX)"),
-        default = "\"abc\".to_string()"
+        env(init_from = &format!("b{}", SUFFIX)),
+        default = "abc"
     )]
     b: String,
     #[source(config = "bpm")]
     c: i32,
-    #[source(default = "HashMap::new()")]
+    #[source(default = HashMap::new())]
     d: HashMap<i32, String>,
 }
 

--- a/config-manager-proc/Cargo.toml
+++ b/config-manager-proc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "config-manager-proc"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 authors = [
     "Mikhail Mikhailov <m.mikhailov@kryptonite.ru>",

--- a/config-manager-proc/src/utils.rs
+++ b/config-manager-proc/src/utils.rs
@@ -3,7 +3,7 @@
 
 use crate::*;
 
-mod attributes;
+pub(crate) mod attributes;
 pub(crate) mod config;
 pub(crate) mod field;
 pub(crate) mod parser;
@@ -19,9 +19,9 @@ macro_rules! format_to_tokens {
 
 macro_rules! meta_value_lit {
     ($($arg:tt)*) => {
-        MetaNameValue {
-            value: Expr::Lit(ExprLit {
-                lit: Lit::Str($($arg)*),
+        syn::MetaNameValue {
+            value: syn::Expr::Lit(syn::ExprLit {
+                lit: syn::Lit::Str($($arg)*),
                 ..
             }),
             ..

--- a/config-manager-proc/src/utils/attributes.rs
+++ b/config-manager-proc/src/utils/attributes.rs
@@ -2,6 +2,9 @@
 // Copyright (c) 2022 JSRPC “Kryptonite”
 
 use strum_macros::EnumIter;
+use syn::{Attribute, Meta};
+
+use super::meta_value_lit;
 
 pub(crate) const CLAP_KEY: &str = "clap";
 pub(crate) const ENV_KEY: &str = "env";
@@ -66,4 +69,21 @@ pub(super) enum ConfigFileAttr {
     Optional,
     #[strum(serialize = "default")]
     Default,
+}
+
+pub(crate) fn extract_docs(attrs: &[Attribute]) -> Option<String> {
+    let mut res = String::new();
+    for attr in attrs {
+        if !attr.meta.path().is_ident("doc") {
+            continue;
+        }
+        if let Meta::NameValue(meta_value_lit!(str_lit)) = &attr.meta {
+            res.push_str(&str_lit.value());
+        }
+    }
+    if res.is_empty() {
+        None
+    } else {
+        Some(res)
+    }
 }

--- a/config-manager-proc/src/utils/field/utils.rs
+++ b/config-manager-proc/src/utils/field/utils.rs
@@ -70,7 +70,14 @@ pub(crate) struct ExtractedAttributes {
 impl ExtractedAttributes {
     fn deserializer(&self) -> TokenStream {
         match &self.deserializer {
-            None => quote!(::config_manager::__private::deser_hjson::from_str(&value)),
+            None => quote! {
+                let value = if value.is_empty() {
+                    "\"\"".to_string()
+                } else {
+                    value
+                };
+                ::config_manager::__private::deser_hjson::from_str(&value)
+            },
             Some(deser_fn) => {
                 let deser_fn = deser_fn.trim_matches('\"');
                 format_to_tokens!("({deser_fn})(&value)")

--- a/config-manager-proc/src/utils/field/utils.rs
+++ b/config-manager-proc/src/utils/field/utils.rs
@@ -278,6 +278,7 @@ pub(super) fn extract_attributes(
 ) -> Option<ExtractedAttributes> {
     let is_bool = field.ty.to_token_stream().to_string() == "bool";
     let is_string = is_string(&field.ty);
+    let docs = extract_docs(&field.attrs);
     let field_name = field.ident.expect("Unnamed fields are forbidden");
 
     let mut res = ExtractedAttributes::default();
@@ -295,11 +296,9 @@ pub(super) fn extract_attributes(
                     .variables
                     .push(FieldAttribute::Clap(ClapFieldParseResult::default())),
                 Meta::List(clap_metalist) => {
-                    res.variables
-                        .push(FieldAttribute::Clap(parse_clap_field_attribute(
-                            &clap_metalist,
-                            is_bool,
-                        )));
+                    let mut clap_attributes = parse_clap_field_attribute(&clap_metalist, is_bool);
+                    clap_attributes.docs = docs.clone();
+                    res.variables.push(FieldAttribute::Clap(clap_attributes));
                 }
                 _ => {
                     panic!(

--- a/config-manager-proc/src/utils/top_level.rs
+++ b/config-manager-proc/src/utils/top_level.rs
@@ -69,6 +69,8 @@ impl ToTokens for NormalClapAppInfo {
 }
 
 pub(crate) fn extract_clap_app(attrs: &[Attribute]) -> NormalClapAppInfo {
+    let docs = extract_docs(attrs);
+
     attrs
         .iter()
         .find(|a| a.path().is_ident(CLAP_KEY))
@@ -80,7 +82,7 @@ pub(crate) fn extract_clap_app(attrs: &[Attribute]) -> NormalClapAppInfo {
             parse_clap_app_attribute(list)
         })
         .unwrap_or_default()
-        .normalize()
+        .normalize(docs)
 }
 
 pub(crate) fn extract_env_prefix(attrs: &[Attribute]) -> Option<String> {

--- a/cookbook.md
+++ b/cookbook.md
@@ -187,7 +187,14 @@ In this case, the initialization order for the `iter` field is:
 
 ### `clap`
 
-Clap app attributes: `name`, `version`, `author`, `about`, `long_about`
+Clap app attributes: `name`, `version`, `author`, `about`, `long_about`.
+
+If on of the attributes is used without value (for example: `clap(name)`):
+- `name`: will be taken as package from Cargo.toml,
+- `version`: will be taken as crate version from Cargo.toml,
+- `author`: will be taken as crate authors from Cargo.toml,
+- `about`: will be taken as crate discription from Cargo.toml,
+- `long_about`: will be taken from doc comments of the struct (aka `///` or `/** */`).
 
 ### `table`
 
@@ -299,17 +306,22 @@ configuration file by the `frame_rate` key.
 
 Clap-crate attributes. Available nested attributes: `help`, `long_help`, `help_heading`, `short`, `long`, `flag`,
 `flatten`, `subcommand`.
-**Note:** the default `long` and `short` values (`#[clap(long)]` and `#[clap(short)]`) is the field name and it's first
-letter. \
-`#[source(clap)]` is equivalent to `#[source(clap(long))]` \
+
+If on of the attributes is used without value (for example: `clap(short)`):
+- `help`: will be taken from doc comments of the field (aka `///` or `/** */`),
+- `long_help`: will be taken from doc comments of the field (aka `///` or `/** */`),
+- `help_heading`: forbidden,
+- `short`: the first letter of the field name,
+- `long`: the field name,
+- `flag`: only the short form allowed.
+
+**Note:** `#[source(clap)]` is equivalent to `#[source(clap(long))]` \
 **Note:** boolean fields can be marked as `#[source(clap(flag))]` that allow to set it as `true` with no value provided. \
 **Example:** the following field can be set to `true` using the CLI: `./my_app -f` or `./my_asp --flag true`.
-```
+```rust
 #[source(clap(long, short, flag))]
-flap: bool
+flag: bool
 ```
-
-In addition, the following attribute can be used.
 
 #### `deserialize_with`
 

--- a/cookbook.md
+++ b/cookbook.md
@@ -313,11 +313,14 @@ In addition, the following attribute can be used.
 
 #### `deserialize_with`
 
-Custom deserialization of the field. The deserialization function must have the signature
+Custom deserialization of the field. The deserialization function should have the following signature:
 
 ```rust
-fn fn_name(s: &str) -> Result<FieldType, String>
+fn fn_name<S: AsRef<str>>(s: S) -> Result<FieldType, impl std::fmt::Display>
 ```
+**Note:** actually, `&String` will be passed to the function, so function can take any argument that is derivable from `&String`.
+It may be `&str`, `&String`, `T: AsRef<str>`, `T: AsRef<String>`, and so on.
+It is recommended to choose error type explicitly.
 
 **Example**
 

--- a/examples/src/demo.rs
+++ b/examples/src/demo.rs
@@ -6,9 +6,10 @@ use config_manager::{config, ConfigInit};
 
 const SUFFIX: &str = "_env";
 
+/// Long about for my App.
 #[derive(Debug)]
 #[config(
-    clap(version, author),
+    clap(version, author, long_about),
     env_prefix = "demo",
     file(
         format = "toml",
@@ -18,7 +19,8 @@ const SUFFIX: &str = "_env";
     )
 )]
 struct MethodConfig {
-    #[source(clap(long, short, help_heading = "A heading"))]
+    /// This docs will be help and long_help.
+    #[source(clap(long, short, help, long_help, help_heading = "A heading"))]
     a: i32,
     #[source(env(init_from = &format!("b{SUFFIX}")), default = "abc")]
     b: String,

--- a/src/__cookbook.rs
+++ b/src/__cookbook.rs
@@ -290,10 +290,14 @@
 //!
 //! In addition, the following attribute can be used.
 //! #### `deserialize_with`
-//! Custom deserialization of the field. The deserialization function must have the signature
+//! Custom deserialization of the field. The deserialization function should have the following signature:
 //! ```ignore
-//! fn fn_name(s: &str) -> Result<FieldType, String>
+//! fn fn_name<S: AsRef<str>>(s: S) -> Result<FieldType, impl std::fmt::Display>
 //! ```
+//! **Note:** actually, `&String` will be passed to the function,
+//! so function can take any argument that is derivable from `&String`.
+//! It may be `&str`, `&String`, `T: AsRef<str>`, `T: AsRef<String>`, and so on.
+//! It is recommended to choose error type explicitly.
 //!
 //! **Example**
 //! ```

--- a/src/__cookbook.rs
+++ b/src/__cookbook.rs
@@ -172,7 +172,14 @@
 //! - default value (`5`)
 //!
 //! ### `clap`
-//! Clap app attributes: `name`, `version`, `author`, `about`, `long_about`
+//! Clap app attributes: `name`, `version`, `author`, `about`, `long_about`.
+//!
+//! If on of the attributes is used without value (for example: `clap(name)`):
+//! - `name`: will be taken as package from Cargo.toml,
+//! - `version`: will be taken as crate version from Cargo.toml,
+//! - `author`: will be taken as crate authors from Cargo.toml,
+//! - `about`: will be taken as crate discription from Cargo.toml,
+//! - `long_about`: will be taken from doc comments of the struct (aka `///` or `/** */`).
 //!
 //! ### `table`
 //! Table of the configuration files to find fields of the structure.
@@ -274,8 +281,16 @@
 //! #### `clap`
 //! Clap-crate attributes. Available nested attributes: `help`, `long_help`, `help_heading`, `short`, `long`, `flag`
 //! `flatten`, `subcommand`.
-//! **Note:** the default `long` and `short` values (`#[clap(long)]` and `#[clap(short)]`) is the field name and it's first letter respectively. \
-//! `#[source(clap)]` is equivalent to `#[source(clap(long))]` \
+//!
+//! If on of the attributes is used without value (for example: `clap(short)`):
+//! - `help`: will be taken from doc comments of the field (aka `///` or `/** */`),
+//! - `long_help`: will be taken from doc comments of the field (aka `///` or `/** */`),
+//! - `help_heading`: forbidden,
+//! - `short`: the first letter of the field name,
+//! - `long`: the field name,
+//! - `flag`: only the short form allowed.
+//!
+//! **Note:** `#[source(clap)]` is equivalent to `#[source(clap(long))]` \
 //! **Note:** boolean fields can be marked as `#[source(clap(flag))]` that allow to set it as `true` with no value provided. \
 //! **Example:** the following field can be set to `true` using the CLI: `./my_app -f` or `./my_asp --flag true`.
 //! ```
@@ -288,7 +303,6 @@
 //! }
 //! ```
 //!
-//! In addition, the following attribute can be used.
 //! #### `deserialize_with`
 //! Custom deserialization of the field. The deserialization function should have the following signature:
 //! ```ignore

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,10 +52,10 @@
 //! use config_manager::{config, ConfigInit};
 //!
 //! const SUFFIX: &str = "_env";
-//!
+//! /// This doc will be included to CLI long_about.
 //! #[derive(Debug)]
 //! #[config(
-//!     clap(version, author),
+//!     clap(version, author, long_about),
 //!     env_prefix = "demo",
 //!     file(
 //!         format = "toml",
@@ -65,7 +65,8 @@
 //!     )
 //! )]
 //! struct MethodConfig {
-//!     #[source(clap(long, short))]
+//!     /// This doc will be included to CLI help.
+//!     #[source(clap(long, short, help))]
 //!     a: i32,
 //!     #[source(
 //!         env(init_from = &format!("b{}", SUFFIX)),

--- a/tests/data/config.toml
+++ b/tests/data/config.toml
@@ -6,6 +6,7 @@ debug_mode = true
 toml = 2
 config = 3
 int_env = 100
+empty = ""
 
 [input]
 int = 5

--- a/tests/mods.rs
+++ b/tests/mods.rs
@@ -2,6 +2,7 @@ mod parse_method {
     mod clap;
     mod default;
     mod deserialize_with;
+    mod empty;
     mod env;
     mod file;
     mod flatten;

--- a/tests/parse_method/empty.rs
+++ b/tests/parse_method/empty.rs
@@ -1,0 +1,44 @@
+use config_manager::config;
+
+use crate::{assert_ok_and_compare, set_env, test_env};
+
+fn empty_env() {
+    fn set_1(_x: &str) -> Result<i32, String> {
+        Ok(1)
+    }
+
+    #[derive(Debug, PartialEq)]
+    #[config(
+        __debug_cmd_input__("--cli=\"\"", "--cli_deser=\"\""),
+        file(format = "toml", default = "./tests/data/config.toml",)
+    )]
+    #[allow(dead_code)]
+    struct EmptyConfig {
+        #[source(clap)]
+        cli: String,
+        #[source(clap, deserialize_with = "set_1")]
+        cli_deser: i32,
+        #[source(env)]
+        env: String,
+        #[source(env, deserialize_with = "set_1")]
+        env_deser: i32,
+        #[source(config = "empty")]
+        file: String,
+        #[source(config = "empty", deserialize_with = "set_1")]
+        file_deser: i32,
+    }
+    set_env("env", "");
+    assert_ok_and_compare(&EmptyConfig {
+        cli: String::new(),
+        cli_deser: 1,
+        env: String::new(),
+        env_deser: 1,
+        file: String::new(),
+        file_deser: 1,
+    });
+}
+
+#[test]
+fn test_empty_string() {
+    test_env(vec![empty_env])
+}

--- a/tests/parse_method/empty.rs
+++ b/tests/parse_method/empty.rs
@@ -3,8 +3,14 @@ use config_manager::config;
 use crate::{assert_ok_and_compare, set_env, test_env};
 
 fn empty_env() {
-    fn set_1(_x: &str) -> Result<i32, String> {
-        Ok(1)
+    fn set(x: &str) -> Result<i32, String> {
+        if x.is_empty() {
+            Ok(1)
+        } else if x == "\"\"" {
+            Ok(2)
+        } else {
+            Err(format!("not empty argument: {x}"))
+        }
     }
 
     #[derive(Debug, PartialEq)]
@@ -16,25 +22,26 @@ fn empty_env() {
     struct EmptyConfig {
         #[source(clap)]
         cli: String,
-        #[source(clap, deserialize_with = "set_1")]
+        #[source(clap, deserialize_with = "set")]
         cli_deser: i32,
         #[source(env)]
         env: String,
-        #[source(env, deserialize_with = "set_1")]
+        #[source(env, deserialize_with = "set")]
         env_deser: i32,
         #[source(config = "empty")]
         file: String,
-        #[source(config = "empty", deserialize_with = "set_1")]
+        #[source(config = "empty", deserialize_with = "set")]
         file_deser: i32,
     }
     set_env("env", "");
+    set_env("env_deser", "");
     assert_ok_and_compare(&EmptyConfig {
         cli: String::new(),
-        cli_deser: 1,
+        cli_deser: 2,
         env: String::new(),
         env_deser: 1,
         file: String::new(),
-        file_deser: 1,
+        file_deser: 2,
     });
 }
 


### PR DESCRIPTION
# Added
- Allow to use clap(help), clap(long_help) and clap(long_about) without value.
Doc comments will be used instead.
# Fixed
- Bug "Can't deserialize ... EoF" on setting empty string via env/cli/config.
# Updated:
- `deserialize_with` documentation.